### PR TITLE
Ensure python3 is used

### DIFF
--- a/vcf2phylip.py
+++ b/vcf2phylip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 


### PR DESCRIPTION
`python` is ambiguous now, ensure 3 is used.